### PR TITLE
Fix feed article image URLs

### DIFF
--- a/source/base/templates/feeds/article_description.html
+++ b/source/base/templates/feeds/article_description.html
@@ -1,7 +1,7 @@
 {% if obj.get_live_author_set().exists() %}<p><strong>{% for author in obj.get_live_author_set() %}{% if loop.first %}By {% endif %}{{ author.name() }}{% if not loop.last %}, {% endif %}{% endfor %}</strong></p>{% endif %}
 
 {% if obj.image %}
-    <img src="//{{ site.domain }}{{ MEDIA_URL }}{{ thumbnail(obj.image, "800") }}" alt="{{ obj.title }}">
+    <img src="{{ MEDIA_URL }}{{ thumbnail(obj.image, "800") }}" alt="{{ obj.title }}">
     {% if obj.pretty_caption %}<p><strong>{{ obj.pretty_caption|safe }}</strong></p>{% endif %}
 {% endif %}
 
@@ -10,7 +10,7 @@
 {% for articleblock in obj.articleblock_set.all() %}
     <h3 id="{{ articleblock.slug }}">{{ articleblock.title }}</h3>
     {% if articleblock.image %}
-        <img src="//{{ site.domain }}{{ MEDIA_URL }}{{ thumbnail(articleblock.image, "300") }}" alt="{{ articleblock.title }}" align="right">
+        <img src="{{ MEDIA_URL }}{{ thumbnail(articleblock.image, "300") }}" alt="{{ articleblock.title }}" align="right">
     {% endif %}
     {{ articleblock.pretty_body_text|safe }}
 {% endfor %}


### PR DESCRIPTION
When I read Source in a feed reader like Feedly the article images are broken:
![screen shot 2017-06-02 at 16 35 38](https://cloud.githubusercontent.com/assets/78356/26730628/ddf77500-47b1-11e7-940a-af982adf6502.png)

The URL Feedly tries to load is:

```
https://source.opennews.orghttps//media.opennews.org/cache/4b/f9/4bf94ad31fcb49b7b1a046845137bc46.jpg
```

`MEDIA_URL` already includes a domain in production settings, so I removed `site.domain`. Additionally the media domain is not your `site.domain`.